### PR TITLE
Add better method to prevent seams

### DIFF
--- a/test.py
+++ b/test.py
@@ -18,5 +18,8 @@ image = load_image_from_url("https://mingukkang.github.io/GigaGAN/static/images/
 upscaled_image = aura_sr.upscale_4x(image)
 upscaled_image.save(os.path.join("test", "output.png"))
 
-upscaled_image = aura_sr.upscale_4x_overlapped(image)
-upscaled_image.save(os.path.join("test", "output_overlapped.png"))
+upscaled_image = aura_sr.upscale_4x_overlapped(image, weight_type='constant')
+upscaled_image.save(os.path.join("test", "output_overlapped_constant.png"))
+
+upscaled_image = aura_sr.upscale_4x_overlapped(image, weight_type='checkboard')
+upscaled_image.save(os.path.join("test", "output_checkerboard.png"))


### PR DESCRIPTION
This is an alternative method to the one just added for preventing seams. 

I noticed that although the seams were lessened, they were still visible, so I added a better way to get rid of them. This makes them completely disappear in my tests. 
New method
<img width="459" alt="Screenshot 2024-07-22 at 11 42 31 PM" src="https://github.com/user-attachments/assets/49704ae8-55d8-4803-a264-fc77635e833c">
Old new method
<img width="372" alt="Screenshot 2024-07-22 at 11 42 51 PM" src="https://github.com/user-attachments/assets/27e3e412-7c1e-499d-91ae-6c3a195d4afb">
Original
<img width="369" alt="Screenshot 2024-07-22 at 11 43 08 PM" src="https://github.com/user-attachments/assets/c552b40f-3249-405b-a725-8b72f0b46095">
